### PR TITLE
interfaz de reporte de daños

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,8 @@ import Map from './components/Map';
 import ApartmentList from './components/ApartmentList';
 import Billing from './components/My-Account/Billing';
 import MyRents from './components/My-Account/MyRents';
+import TenantMaintenance from './components/TenantMaintenance';
+import LandlordMaintenance from './components/LandlordMaintenance';
 import './App.css';
 
 function ListingsPage({ goToJoin, listingSearch, setListingSearch, listingFilters }) {
@@ -157,6 +159,8 @@ function AppContent() {
           <Route path='/listings' element={<ListingsPage goToJoin={toggleJoin} listingSearch={listingSearch} setListingSearch={setListingSearch} listingFilters={listingFilters} />} />
           <Route path='/facturacion' element={<ProtectedRoute><FacturacionPage /></ProtectedRoute>} />
           <Route path='/mis-arriendos' element={<ProtectedRoute><MyRentsPage /></ProtectedRoute>} />
+          <Route path='/mis-reportes' element={<ProtectedRoute requiredRole={1} fallbackPath="/"><TenantMaintenance /></ProtectedRoute>} />
+          <Route path='/mantenimiento-panel' element={<ProtectedRoute requiredRole={2} fallbackPath="/"><LandlordMaintenance /></ProtectedRoute>} />
         </Routes>
       </div>
     </>

--- a/src/apis/maintenanceController.js
+++ b/src/apis/maintenanceController.js
@@ -1,0 +1,36 @@
+import axiosInstance from "../contexts/axiosInstance";
+
+export const createMaintenanceReport = async (data) => {
+    const response = await axiosInstance.post('/maintenance/create', data);
+    return response.data;
+};
+
+export const getMyReports = async () => {
+    const response = await axiosInstance.get('/maintenance/my-reports');
+    return response.data;
+};
+
+export const getMyProperties = async () => {
+    const response = await axiosInstance.get('/maintenance/my-properties');
+    return response.data;
+};
+
+export const getLandlordReports = async () => {
+    const response = await axiosInstance.get('/maintenance/landlord');
+    return response.data;
+};
+
+export const getPropertyReports = async (propertyId) => {
+    const response = await axiosInstance.get(`/maintenance/property/${propertyId}`);
+    return response.data;
+};
+
+export const updateReportStatus = async (reportId, status, landlord_notes) => {
+    const response = await axiosInstance.put(`/maintenance/${reportId}/status`, { status, landlord_notes });
+    return response.data;
+};
+
+export const deleteReport = async (reportId) => {
+    const response = await axiosInstance.delete(`/maintenance/${reportId}`);
+    return response.data;
+};

--- a/src/components/LandlordMaintenance.jsx
+++ b/src/components/LandlordMaintenance.jsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect, useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+import { getLandlordReports, updateReportStatus, deleteReport } from "../apis/maintenanceController";
+import "./MaintenanceList.css";
+
+const STATUS_LABELS = {
+    pending: "Pendiente", in_progress: "En Proceso", resolved: "Resuelto", rejected: "Rechazado"
+};
+const PRIORITY_LABELS = {
+    low: "Baja", medium: "Media", high: "Alta", urgent: "Urgente"
+};
+
+export default function LandlordMaintenance() {
+    const { user } = useContext(UserContext);
+    const [reports, setReports] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [toast, setToast] = useState(null);
+
+    const fetchReports = () => {
+        if (!user) return;
+        setLoading(true);
+        getLandlordReports()
+            .then((res) => { if (res.success) setReports(res.data); })
+            .finally(() => setLoading(false));
+    };
+
+    useEffect(() => { fetchReports(); }, [user]);
+
+    const handleStatusChange = async (reportId, newStatus) => {
+        const notes = newStatus === "rejected" ? prompt("Motivo del rechazo:") : null;
+        if (newStatus === "rejected" && !notes) return;
+        try {
+            const res = await updateReportStatus(reportId, newStatus, notes);
+            if (res.success) {
+                setToast({ msg: `Reporte actualizado a "${STATUS_LABELS[newStatus]}"`, type: "success" });
+                fetchReports();
+            }
+        } catch {
+            setToast({ msg: "Error actualizando reporte", type: "error" });
+        }
+    };
+
+    const handleDelete = async (id) => {
+        if (!window.confirm('¿Eliminar este reporte? También se borrará la imagen adjunta.')) return;
+        try {
+            const res = await deleteReport(id);
+            if (res.success) {
+                setToast({ msg: 'Reporte eliminado', type: 'success' });
+                fetchReports();
+            }
+        } catch {
+            setToast({ msg: 'Error al eliminar el reporte', type: 'error' });
+        }
+    };
+
+    return (
+        <div className="maintenance-list-container">
+            <h2>Mantenimiento - Mis Propiedades</h2>
+            {loading ? <p>Cargando...</p> : reports.length === 0 ? (
+                <div className="maintenance-list-empty">
+                    <p>No hay reportes de mantenimiento en tus propiedades.</p>
+                </div>
+            ) : (
+                reports.map((r) => (
+                    <div key={r.id} className="maintenance-card">
+                        <div className="maintenance-card-info">
+                            <h4>{r.title}</h4>
+                            <p className="property">{r.direccion_apt} - {r.barrio}</p>
+                            <p style={{ fontSize: 13, color: "#555" }}>
+                                Reportado por: {r.user_name} {r.user_lastname} | {r.user_phonenumber}
+                            </p>
+                            <p>{r.description}</p>
+                            <p>
+                                <span className={`priority-badge priority-${r.priority}`}>
+                                    {PRIORITY_LABELS[r.priority]}
+                                </span>
+                                {" "}
+                                <span className={`badge badge-${r.status}`}>
+                                    {STATUS_LABELS[r.status]}
+                                </span>
+                            </p>
+                            {r.landlord_notes && (
+                                <p style={{ fontSize: 13, color: "#555", fontStyle: "italic" }}>
+                                    Nota: {r.landlord_notes}
+                                </p>
+                            )}
+                            <small style={{ color: "#aaa" }}>
+                                {new Date(r.created_at).toLocaleDateString("es-CO", {
+                                    day: "numeric", month: "long", year: "numeric"
+                                })}
+                            </small>
+                            <div style={{ marginTop: 10 }}>
+                                {r.status === "pending" && (
+                                    <>
+                                        <button className="btn-status in-progress" onClick={() => handleStatusChange(r.id, "in_progress")}>
+                                            Iniciar
+                                        </button>
+                                        <button className="btn-status rejected" onClick={() => handleStatusChange(r.id, "rejected")}>
+                                            Rechazar
+                                        </button>
+                                    </>
+                                )}
+                                {r.status === "in_progress" && (
+                                    <>
+                                        <button className="btn-status resolved" onClick={() => handleStatusChange(r.id, "resolved")}>
+                                            Resolver
+                                        </button>
+                                        <button className="btn-status rejected" onClick={() => handleStatusChange(r.id, "rejected")}>
+                                            Rechazar
+                                        </button>
+                                    </>
+                                )}
+                                <button className="btn-status delete" onClick={() => handleDelete(r.id)}>
+                                    Eliminar
+                                </button>
+                            </div>
+                        </div>
+                        {r.image_url && (
+                            <img
+                                src={r.image_url}
+                                alt="Reporte"
+                                className="maintenance-image"
+                                onError={(e) => { e.target.style.display = "none"; }}
+                            />
+                        )}
+                    </div>
+                ))
+            )}
+            {toast && (
+                <div className={`toast toast-${toast.type}`} onClick={() => setToast(null)}>
+                    {toast.msg}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/MaintenanceList.css
+++ b/src/components/MaintenanceList.css
@@ -1,0 +1,74 @@
+.maintenance-list-container {
+    max-width: 900px;
+    margin: 40px auto;
+    padding: 24px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+}
+.maintenance-list-container h2 {
+    margin-bottom: 20px;
+    color: #333;
+}
+.maintenance-card {
+    border: 1px solid #eee;
+    border-radius: 10px;
+    padding: 16px;
+    margin-bottom: 14px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+.maintenance-card-info { flex: 1; }
+.maintenance-card-info h4 { margin: 0 0 6px; color: #2c3e50; }
+.maintenance-card-info p { margin: 2px 0; color: #666; font-size: 14px; }
+.maintenance-card-info .property { font-weight: 600; color: #e67e22; }
+.badge {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.badge-pending { background: #fef3cd; color: #856404; }
+.badge-in_progress { background: #cce5ff; color: #004085; }
+.badge-resolved { background: #d4edda; color: #155724; }
+.badge-rejected { background: #f8d7da; color: #721c24; }
+.priority-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+}
+.priority-low { background: #e8f5e9; color: #2e7d32; }
+.priority-medium { background: #fff3e0; color: #e65100; }
+.priority-high { background: #fce4ec; color: #c62828; }
+.priority-urgent { background: #fce4ec; color: #b71c1c; font-weight: 800; }
+.maintenance-list-empty {
+    text-align: center;
+    padding: 60px 20px;
+    color: #999;
+}
+.maintenance-image {
+    max-width: 120px;
+    max-height: 120px;
+    border-radius: 8px;
+    margin-left: 16px;
+    object-fit: cover;
+}
+.btn-status {
+    padding: 6px 16px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-right: 8px;
+}
+.btn-status.in-progress { background: #cce5ff; color: #004085; }
+.btn-status.resolved { background: #d4edda; color: #155724; }
+.btn-status.rejected { background: #f8d7da; color: #721c24; }
+.btn-status.delete { background: #fee2e2; color: #991b1b; }
+

--- a/src/components/MaintenanceList.jsx
+++ b/src/components/MaintenanceList.jsx
@@ -1,0 +1,96 @@
+import React, { useState, useEffect, useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+import { getMyReports, deleteReport } from "../apis/maintenanceController";
+import "./MaintenanceList.css";
+
+const STATUS_LABELS = {
+    pending: "Pendiente", in_progress: "En Proceso", resolved: "Resuelto", rejected: "Rechazado"
+};
+const PRIORITY_LABELS = {
+    low: "Baja", medium: "Media", high: "Alta", urgent: "Urgente"
+};
+
+export default function MaintenanceList({ refreshKey }) {
+    const { user } = useContext(UserContext);
+    const [reports, setReports] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!user) return;
+        loadReports();
+    }, [user, refreshKey]);
+
+    const loadReports = () => {
+        setLoading(true);
+        getMyReports()
+            .then((res) => { if (res.success) setReports(res.data); })
+            .finally(() => setLoading(false));
+    };
+
+    const handleDelete = async (id) => {
+        if (!window.confirm('¿Eliminar este reporte? También se borrará la imagen adjunta.')) return;
+        try {
+            const res = await deleteReport(id);
+            if (res.success) {
+                setReports(prev => prev.filter(r => r.id !== id));
+            }
+        } catch {
+            alert('Error al eliminar el reporte');
+        }
+    };
+
+    if (loading) return <div className="maintenance-list-container"><p>Cargando...</p></div>;
+
+    return (
+        <div className="maintenance-list-container">
+            <h2>Mis Reportes</h2>
+            {reports.length === 0 ? (
+                <div className="maintenance-list-empty">
+                    <p>No has realizado ningún reporte de mantenimiento.</p>
+                </div>
+            ) : (
+                reports.map((r) => (
+                    <div key={r.id} className="maintenance-card">
+                        <div className="maintenance-card-info">
+                            <h4>{r.title}</h4>
+                            <p className="property">{r.direccion_apt} - {r.barrio}</p>
+                            <p>{r.description}</p>
+                            <p>
+                                <span className={`priority-badge priority-${r.priority}`}>
+                                    {PRIORITY_LABELS[r.priority] || r.priority}
+                                </span>
+                                {" "}
+                                <span className={`badge badge-${r.status}`}>
+                                    {STATUS_LABELS[r.status] || r.status}
+                                </span>
+                            </p>
+                            {r.landlord_notes && (
+                                <p style={{ fontSize: 13, color: "#555", fontStyle: "italic" }}>
+                                    Nota: {r.landlord_notes}
+                                </p>
+                            )}
+                            <small style={{ color: "#aaa" }}>
+                                {new Date(r.created_at).toLocaleDateString("es-CO", {
+                                    day: "numeric", month: "long", year: "numeric"
+                                })}
+                            </small>
+                            <div style={{ marginTop: 8 }}>
+                                <button className="btn-status rejected" onClick={() => handleDelete(r.id)}>
+                                    Eliminar
+                                </button>
+                            </div>
+                        </div>
+                        {r.image_url && (
+                            <img
+                                src={r.image_url}
+                                alt="Reporte"
+                                className="maintenance-image"
+                                onError={(e) => { e.target.style.display = "none"; }}
+                            />
+                        )}
+                    </div>
+                ))
+            )}
+        </div>
+    );
+}

--- a/src/components/MaintenanceReport.css
+++ b/src/components/MaintenanceReport.css
@@ -1,0 +1,63 @@
+.maintenance-report-container {
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 24px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+}
+.maintenance-report-container h2 {
+    margin-bottom: 20px;
+    color: #333;
+}
+.maintenance-form label {
+    display: block;
+    margin-top: 16px;
+    font-weight: 600;
+    color: #555;
+}
+.maintenance-form input,
+.maintenance-form select,
+.maintenance-form textarea {
+    width: 100%;
+    padding: 10px 12px;
+    margin-top: 4px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+.maintenance-form textarea {
+    resize: vertical;
+}
+.maintenance-form button {
+    margin-top: 24px;
+    width: 100%;
+    padding: 12px;
+    background: #e67e22;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.maintenance-form button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+.toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 14px 28px;
+    border-radius: 8px;
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    z-index: 9999;
+}
+.toast-success { background: #27ae60; }
+.toast-error { background: #e74c3c; }
+.toast-warning { background: #f39c12; }

--- a/src/components/MaintenanceReport.jsx
+++ b/src/components/MaintenanceReport.jsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect, useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+import { getMyProperties, createMaintenanceReport } from "../apis/maintenanceController";
+import "./MaintenanceReport.css";
+
+const PRIORITIES = [
+    { value: "low", label: "Baja" },
+    { value: "medium", label: "Media" },
+    { value: "high", label: "Alta" },
+    { value: "urgent", label: "Urgente" },
+];
+
+export default function MaintenanceReport({ onSuccess }) {
+    const { user } = useContext(UserContext);
+    const [properties, setProperties] = useState([]);
+    const [form, setForm] = useState({
+        property_id: "", title: "", description: "", priority: "medium"
+    });
+    const [image, setImage] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [toast, setToast] = useState(null);
+
+    useEffect(() => {
+        if (!user) return;
+        setLoading(true);
+        getMyProperties()
+            .then((res) => { if (res.success) setProperties(res.data); })
+            .catch(() => setToast({ msg: "Error cargando propiedades", type: "error" }))
+            .finally(() => setLoading(false));
+    }, [user]);
+
+    const handleChange = (e) => {
+        setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!form.property_id || !form.title) {
+            setToast({ msg: "Selecciona una propiedad y escribe un título", type: "warning" });
+            return;
+        }
+        const formData = new FormData();
+        formData.append("property_id", form.property_id);
+        formData.append("title", form.title);
+        formData.append("description", form.description);
+        formData.append("priority", form.priority);
+        if (image) formData.append("image", image);
+
+        setSubmitting(true);
+        try {
+            const res = await createMaintenanceReport(formData);
+            if (res.success) {
+                setToast({ msg: "Reporte creado exitosamente", type: "success" });
+                setForm({ property_id: "", title: "", description: "", priority: "medium" });
+                setImage(null);
+                if (onSuccess) onSuccess();
+            }
+        } catch (err) {
+            setToast({ msg: err.response?.data?.error || "Error al crear reporte", type: "error" });
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="maintenance-report-container">
+            <h2>Reportar Mantenimiento</h2>
+            <form onSubmit={handleSubmit} className="maintenance-form">
+                <label>Propiedad</label>
+                <select name="property_id" value={form.property_id} onChange={handleChange} required>
+                    <option value="">{loading ? "Cargando..." : properties.length === 0 ? "Sin propiedades activas" : "-- Selecciona --"}</option>
+                    {properties.map((p) => (
+                        <option key={p.id_apt} value={p.id_apt}>
+                            {p.direccion_apt} - {p.barrio}
+                        </option>
+                    ))}
+                </select>
+
+                <label>Título</label>
+                <input name="title" value={form.title} onChange={handleChange} placeholder="Ej: Fuga de agua" required />
+
+                <label>Descripción</label>
+                <textarea name="description" value={form.description} onChange={handleChange} rows={3} />
+
+                <label>Prioridad</label>
+                <select name="priority" value={form.priority} onChange={handleChange}>
+                    {PRIORITIES.map((p) => (
+                        <option key={p.value} value={p.value}>{p.label}</option>
+                    ))}
+                </select>
+
+                <label>Foto (opcional)</label>
+                <input type="file" accept="image/*" onChange={(e) => setImage(e.target.files[0])} />
+
+                <button type="submit" disabled={submitting}>
+                    {submitting ? "Enviando..." : "Enviar Reporte"}
+                </button>
+            </form>
+
+            {toast && (
+                <div className={`toast toast-${toast.type}`} onClick={() => setToast(null)}>
+                    {toast.msg}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -106,6 +106,12 @@ function Navbar({ goToJoin, setShowAccount, listingSearch, setListingSearch, lis
               >
                 Mis Arriendos
               </button>
+              <button
+                onClick={() => { window.scrollTo(0, 0); navigate('/mis-reportes'); }}
+                className="px-3 py-1.5 rounded-full text-sm text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors"
+              >
+                Mantenimiento
+              </button>
             </div>
           )}
           {/* Desktop: user actions */}
@@ -125,6 +131,12 @@ function Navbar({ goToJoin, setShowAccount, listingSearch, setListingSearch, lis
                     <button onClick={() => { window.scrollTo(0, 0); navigate('/dashboard'); }} className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
                       <span className="material-symbols-outlined text-sm">dashboard</span>
                       <span>Panel</span>
+                    </button>
+                )}
+                {userRole === 2 && (
+                    <button onClick={() => { window.scrollTo(0, 0); navigate('/mantenimiento-panel'); }} className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
+                      <span className="material-symbols-outlined text-sm">build</span>
+                      <span>Mantenimiento</span>
                     </button>
                 )}
                 {userRole === 3 && (
@@ -225,11 +237,19 @@ function Navbar({ goToJoin, setShowAccount, listingSearch, setListingSearch, lis
                     <button onClick={() => { window.scrollTo(0, 0); navigate('/mis-arriendos'); setIsMenuOpen(false); }} className="w-full text-left text-sm py-2 px-3 rounded-lg text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
                       Mis Arriendos
                     </button>
+                    <button onClick={() => { window.scrollTo(0, 0); navigate('/mis-reportes'); setIsMenuOpen(false); }} className="w-full text-left text-sm py-2 px-3 rounded-lg text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
+                      Mantenimiento
+                    </button>
                   </>
                 )}
                 {userRole === 2 && (
                   <button onClick={() => { window.scrollTo(0, 0); navigate('/dashboard'); setIsMenuOpen(false); }} className="w-full text-left text-sm py-2 px-3 rounded-lg text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
                     Panel de Gestión
+                  </button>
+                )}
+                {userRole === 2 && (
+                  <button onClick={() => { window.scrollTo(0, 0); navigate('/mantenimiento-panel'); setIsMenuOpen(false); }} className="w-full text-left text-sm py-2 px-3 rounded-lg text-ink-soft hover:bg-paper-sunk hover:text-ink transition-colors">
+                    Mantenimiento
                   </button>
                 )}
                 {userRole === 3 && (

--- a/src/components/TenantMaintenance.jsx
+++ b/src/components/TenantMaintenance.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from "react";
+import MaintenanceReport from "./MaintenanceReport";
+import MaintenanceList from "./MaintenanceList";
+
+export default function TenantMaintenance() {
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    const handleReportCreated = () => {
+        setRefreshKey((k) => k + 1);
+    };
+
+    return (
+        <div>
+            <MaintenanceReport onSuccess={handleReportCreated} />
+            <MaintenanceList refreshKey={refreshKey} />
+        </div>
+    );
+}


### PR DESCRIPTION
### Descripción

Se crearon las pantallas para que los inquilinos puedan reportar problemas de mantenimiento (seleccionando su propiedad, agregando título, descripción, prioridad y foto) y ver una lista de todos sus reportes con su estado actual. También se hizo un panel para que los arrendadores vean los reportes de todas sus propiedades y puedan cambiar el estado (iniciar, resolver, rechazar) o eliminar reportes. Todo esto se conectó con botones en el menú de navegación según el tipo de usuario.