### PR TITLE
opción de activar/desactivar notificaciones push

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -9,28 +9,37 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('push', (event) => {
   if (!event.data) return;
 
-  try {
-    const data = event.data.json();
-    const { title, body, icon, badge, data: payload } = data;
+  let notificationData;
 
-    event.waitUntil(
-      self.registration.showNotification(title || 'RentUp', {
-        body: body || '',
-        icon: icon || '/favicon.ico',
-        badge: badge || '/favicon.ico',
-        vibrate: [200, 100, 200],
-        tag: payload?.url || 'rentup-default',
-        data: payload || {},
-        requireInteraction: true,
-        actions: [
-          { action: 'open', title: 'Abrir' },
-          { action: 'close', title: 'Cerrar' },
-        ],
-      })
-    );
-  } catch (e) {
-    console.error('Error processing push event:', e);
+  try {
+    notificationData = event.data.json();
+  } catch {
+    const text = event.data.text();
+    notificationData = {
+      title: 'RentUp',
+      body: text,
+      tag: `rentup-raw-${Date.now()}`,
+      data: { url: '/' },
+    };
   }
+
+  const { title, body, icon, badge, tag, data: payload } = notificationData;
+
+  event.waitUntil(
+    self.registration.showNotification(title || 'RentUp', {
+      body: body || '',
+      icon: icon || '/favicon.ico',
+      badge: badge || '/favicon.ico',
+      vibrate: [200, 100, 200],
+      tag: tag || `rentup-${Date.now()}`,
+      data: payload || {},
+      requireInteraction: true,
+      actions: [
+        { action: 'open', title: 'Abrir' },
+        { action: 'close', title: 'Cerrar' },
+      ],
+    })
+  );
 });
 
 self.addEventListener('notificationclick', (event) => {

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -1,6 +1,7 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { UserContext } from "../contexts/UserContext";
 import { useNavigate } from 'react-router-dom';
+import { usePushNotifications } from './PushNotificationProvider';
 
 function Account({ onClose, onLogoutSuccess }) {
     const navigate = useNavigate();
@@ -8,6 +9,7 @@ function Account({ onClose, onLogoutSuccess }) {
     const [showConfirmLogout, setShowConfirmLogout] = useState(false);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const { status: pushStatus, enable: enablePush, disable: disablePush } = usePushNotifications();
     const userRole = user?.rol || user?.rol_id || user?.rolId || null;
 
     if (!user) return null;
@@ -127,7 +129,72 @@ function Account({ onClose, onLogoutSuccess }) {
                                 </div>
                             </div>
 
-                            <div className="mt-5 space-y-2">
+                            <div className="mt-4 bg-surface-container-low rounded-xl p-3">
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-2">
+                                        <span className="material-symbols-outlined text-sm text-outline">notifications</span>
+                                        <span className="text-label-md text-on-surface">Notificaciones push</span>
+                                    </div>
+                                    {pushStatus === 'active' || pushStatus === 'registered' ? (
+                                        <button
+                                            onClick={disablePush}
+                                            className="text-xs bg-green-100 text-green-700 px-2.5 py-1 rounded-full font-medium hover:bg-red-100 hover:text-red-700 transition-all"
+                                            title="Desactivar notificaciones push"
+                                        >
+                                            Activadas
+                                        </button>
+                                    ) : pushStatus === 'requesting-permission' || pushStatus === 'registering-sw' || pushStatus === 'subscribing' || pushStatus === 'getting-key' ? (
+                                        <span className="text-xs text-outline animate-pulse">Activando...</span>
+                                    ) : pushStatus === 'disabled' || pushStatus === 'inactive' || pushStatus === 'idle' ? (
+                                        <button
+                                            onClick={enablePush}
+                                            className="text-xs bg-surface-container-highest text-outline px-2.5 py-1 rounded-full font-medium hover:bg-brand-50 hover:text-brand-500 transition-all"
+                                        >
+                                            Activar
+                                        </button>
+                                    ) : (
+                                        <span className="text-xs text-outline">{pushStatus}</span>
+                                    )}
+                                </div>
+                                {pushStatus === 'denied' && (
+                                    <div className="mt-1">
+                                        <p className="text-xs text-error">Bloqueado por el navegador.</p>
+                                        <p className="text-xs text-on-surface-variant mt-0.5">
+                                            Haz click en el candado 🔒 junto a la URL → Notificaciones → Permitir
+                                        </p>
+                                        <button
+                                            onClick={enablePush}
+                                            className="text-xs text-brand-500 font-medium mt-1 hover:underline"
+                                        >
+                                            Reintentar después de cambiar
+                                        </button>
+                                    </div>
+                                )}
+                                {pushStatus === 'failed' && (
+                                    <p className="text-xs text-warning mt-1">Error al activar. Intenta de nuevo.</p>
+                                )}
+                                {pushStatus === 'active' && (
+                                    <button
+                                        onClick={async () => {
+                                            try {
+                                                const token = JSON.parse(localStorage.getItem('user') || '{}').token;
+                                                if (!token) return;
+                                                await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:9000'}/push/test`, {
+                                                    method: 'POST',
+                                                    headers: { 'Authorization': `Bearer ${token}` }
+                                                });
+                                            } catch (e) {
+                                                console.error('Test push error:', e);
+                                            }
+                                        }}
+                                        className="text-xs text-brand-500 font-medium mt-1 hover:underline"
+                                    >
+                                        Enviar notificación de prueba
+                                    </button>
+                                )}
+                            </div>
+
+                            <div className="mt-4 space-y-2">
                                 <button
                                     onClick={handleLogoutClick}
                                     className="w-full bg-brand-500 text-white font-semibold py-2.5 rounded-lg hover:bg-brand-500/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"

--- a/src/components/PushNotificationProvider.jsx
+++ b/src/components/PushNotificationProvider.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useContext, useRef, useState, useCallback } from 'react';
+import { UserContext } from '../contexts/UserContext';
+import { registerServiceWorker, getVapidPublicKey, subscribeToPush, unsubscribeFromPush } from '../utils/pushNotifications';
+
+export default function PushNotificationProvider({ children }) {
+  const { user } = useContext(UserContext);
+  const autoSubscribed = useRef(false);
+
+  useEffect(() => {
+    if (!user?.token || autoSubscribed.current) return;
+
+    if (!('Notification' in window) || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+      return;
+    }
+
+    if (Notification.permission !== 'granted') return;
+
+    const token = user.token;
+
+    async function autoSubscribe() {
+      try {
+        const existing = await navigator.serviceWorker.getRegistration('/');
+        const registration = existing || await registerServiceWorker();
+        if (!registration) return;
+
+        const vapidPublicKey = await getVapidPublicKey();
+        if (!vapidPublicKey) return;
+
+        const sub = await subscribeToPush(registration, vapidPublicKey, token);
+        if (sub) {
+          autoSubscribed.current = true;
+        }
+      } catch (err) {
+        console.error('Push auto-subscribe error:', err);
+      }
+    }
+
+    autoSubscribe();
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) autoSubscribed.current = false;
+  }, [user]);
+
+  return children;
+}
+
+export function usePushNotifications() {
+  const { user } = useContext(UserContext);
+  const [status, setStatus] = useState('idle');
+
+  useEffect(() => {
+    if (!user?.token) {
+      setStatus('idle');
+      return;
+    }
+
+    async function checkExisting() {
+      const perm = Notification.permission;
+      if (perm !== 'granted') {
+        setStatus('inactive');
+        return;
+      }
+
+      try {
+        const registration = await navigator.serviceWorker.getRegistration('/');
+        if (!registration) {
+          setStatus('inactive');
+          return;
+        }
+        const subscription = await registration.pushManager.getSubscription();
+        setStatus(subscription ? 'active' : 'inactive');
+      } catch {
+        setStatus('inactive');
+      }
+    }
+
+    checkExisting();
+  }, [user]);
+
+  const enable = useCallback(async () => {
+    if (!user?.token) return false;
+
+    if (!('Notification' in window)) {
+      setStatus('unsupported');
+      return false;
+    }
+
+    setStatus('requesting-permission');
+
+    let permission = Notification.permission;
+    if (permission === 'default') {
+      permission = await Notification.requestPermission();
+    }
+
+    if (permission !== 'granted') {
+      setStatus('denied');
+      return false;
+    }
+
+    setStatus('registering-sw');
+    const registration = await registerServiceWorker();
+    if (!registration) {
+      setStatus('failed');
+      return false;
+    }
+
+    setStatus('getting-key');
+    const key = await getVapidPublicKey();
+    if (!key) {
+      setStatus('failed');
+      return false;
+    }
+
+    setStatus('subscribing');
+    const sub = await subscribeToPush(registration, key, user.token);
+    if (sub) {
+      setStatus('active');
+      return true;
+    }
+
+    setStatus('failed');
+    return false;
+  }, [user]);
+
+  const disable = useCallback(async () => {
+    await unsubscribeFromPush(user?.token);
+    setStatus('disabled');
+  }, [user]);
+
+  return { status, enable, disable };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { UserProvider } from './contexts/UserContext';
+import PushNotificationProvider from './components/PushNotificationProvider';
 import reportWebVitals from './reportWebVitals';
 import 'leaflet/dist/leaflet.css';
 
@@ -10,7 +11,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <React.StrictMode>
         <UserProvider>
-            <App />
+            <PushNotificationProvider>
+                <App />
+            </PushNotificationProvider>
         </UserProvider>
     </React.StrictMode>
 );

--- a/src/utils/pushNotifications.js
+++ b/src/utils/pushNotifications.js
@@ -2,19 +2,26 @@ const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:9000';
 
 export async function registerServiceWorker() {
   if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    console.log('Push notifications not supported');
+    console.log('❌ Push notifications not supported in this browser');
     return null;
   }
 
   try {
+    const existing = await navigator.serviceWorker.getRegistration('/');
+    if (existing) {
+      console.log('✅ Service Worker ya registrado');
+      await existing.update();
+      return existing;
+    }
+
     const registration = await navigator.serviceWorker.register('/service-worker.js', {
       scope: '/',
       updateViaCache: 'none',
     });
-    console.log('Service Worker registered');
+    console.log('✅ Service Worker registrado correctamente');
     return registration;
   } catch (err) {
-    console.error('Service Worker registration failed:', err);
+    console.error('❌ Service Worker registration failed:', err);
     return null;
   }
 }
@@ -22,15 +29,17 @@ export async function registerServiceWorker() {
 export async function getVapidPublicKey() {
   try {
     const res = await fetch(`${API_URL}/push/vapid-public-key`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
+    console.log('✅ VAPID public key obtenida');
     return data.publicKey;
   } catch (err) {
-    console.error('Error fetching VAPID public key:', err);
+    console.error('❌ Error fetching VAPID public key:', err);
     return null;
   }
 }
 
-async function urlBase64ToUint8Array(base64String) {
+function urlBase64ToUint8Array(base64String) {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = window.atob(base64);
@@ -38,20 +47,24 @@ async function urlBase64ToUint8Array(base64String) {
 }
 
 export async function subscribeToPush(registration, vapidPublicKey, token) {
-  if (!registration || !vapidPublicKey || !token) return null;
+  if (!registration || !vapidPublicKey || !token) {
+    console.log('❌ subscribeToPush: missing params', { hasReg: !!registration, hasKey: !!vapidPublicKey, hasToken: !!token });
+    return null;
+  }
 
   try {
     let subscription = await registration.pushManager.getSubscription();
+    console.log('ℹ️ Push subscription existente:', subscription ? 'SÍ' : 'NO');
 
     if (!subscription) {
-      const convertedKey = await urlBase64ToUint8Array(vapidPublicKey);
+      const convertedKey = urlBase64ToUint8Array(vapidPublicKey);
       subscription = await registration.pushManager.subscribe({
         userVisibleOnly: true,
         applicationServerKey: convertedKey,
       });
+      console.log('✅ Nueva suscripción push creada');
     }
 
-    // Send subscription to backend
     const subData = subscription.toJSON();
 
     const res = await fetch(`${API_URL}/push/subscribe`, {
@@ -63,11 +76,14 @@ export async function subscribeToPush(registration, vapidPublicKey, token) {
       body: JSON.stringify(subData),
     });
 
-    if (!res.ok) throw new Error('Failed to subscribe on server');
-    console.log('Push subscription registered on server');
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`HTTP ${res.status}: ${errText}`);
+    }
+    console.log('✅ Suscripción push registrada en el servidor');
     return subscription;
   } catch (err) {
-    console.error('Error subscribing to push:', err);
+    console.error('❌ Error subscribing to push:', err);
     return null;
   }
 }
@@ -82,6 +98,7 @@ export async function unsubscribeFromPush(token) {
     if (subscription) {
       const subData = subscription.toJSON();
       await subscription.unsubscribe();
+      console.log('✅ Push unsubscribed from browser');
 
       await fetch(`${API_URL}/push/unsubscribe`, {
         method: 'POST',
@@ -91,8 +108,26 @@ export async function unsubscribeFromPush(token) {
         },
         body: JSON.stringify({ endpoint: subData.endpoint }),
       });
+      console.log('✅ Push unsubscribed from server');
     }
   } catch (err) {
-    console.error('Error unsubscribing:', err);
+    console.error('❌ Error unsubscribing:', err);
   }
+}
+
+export async function checkNotificationPermission() {
+  if (!('Notification' in window)) {
+    return { granted: false, reason: 'API no soportada' };
+  }
+
+  if (Notification.permission === 'granted') {
+    return { granted: true };
+  }
+
+  if (Notification.permission === 'denied') {
+    return { granted: false, reason: 'Bloqueado por el usuario' };
+  }
+
+  const permission = await Notification.requestPermission();
+  return { granted: permission === 'granted', reason: permission };
 }


### PR DESCRIPTION
### Descripción

Se agregó la lógica para activar/desactivar notificaciones push desde el menú de cuenta, un botón para probarlas, y el registro automático al iniciar sesión si el permiso ya está concedido. También se mejoró el service worker para que las notificaciones lleguen incluso cuando la página está cerrada.