### PR TITLE
fix: quitar pnpm-lock.yaml de .dockerignore para build docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ CODEOWNERS
 .prettierrc
 .eslintrc.json
 .npmrc
-pnpm-lock.yaml


### PR DESCRIPTION
### Descripción

Se removio pnpm-lock.yaml del .dockerignore para  compilar