### PR TITLE
feat: agregar env_file y host.docker.internal al docker-compose 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,4 +34,4 @@ jobs:
       run: CI=false pnpm build
 
     - name: Test
-      run: pnpm test -- --watchAll=false || true
+      run: pnpm test -- --watchAll=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     build: .
     ports:
       - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      - REACT_APP_API_URL=http://host.docker.internal:9000
+      - REACT_APP_SOCKET_URL=http://host.docker.internal:9000
     networks:
       - rentup-network
 


### PR DESCRIPTION
### Descripción

Ahora si se comunica con el backend, al bajar el .env y escuchar los host que se levantan en docker